### PR TITLE
Update moose-dev-clang

### DIFF
--- a/Formula/moose.rb
+++ b/Formula/moose.rb
@@ -3,7 +3,7 @@ class Moose < Formula
   homepage "https://mooseframework.org"
   url "http://mooseframework.org/source_packages/moose-modules.tar.gz"
   sha256 "444cc515c75966135975ae439875c43001d9631a6c0c5ee2477d0eecf77e643b"
-  revision 1
+  revision 2
 
   keg_only "we want to leverage the module load command"
   depends_on "modules"
@@ -31,6 +31,7 @@ setenv PETSC_DIR #{petsc_path}
 setenv LIBMESH_DIR #{libmesh_path}
 setenv VTKINCLUDE_DIR #{vtk_include}
 setenv VTKLIB_DIR #{vtk_lib}
+setenv OMPI_MCA_rmaps_base_oversubscribe 1
 setenv CC mpicc
 setenv CXX mpicxx
 setenv FC mpif90


### PR DESCRIPTION
Allow oversubscribing to OpenMPI